### PR TITLE
Simplify `clap` usage

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -87,7 +87,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "clap"
 version = "3.0.0-beta.2"
-source = "git+https://github.com/clap-rs/clap/#52814b893c87e1c0350cae13fc1988fe2aa9886a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
 dependencies = [
  "atty",
  "bitflags",
@@ -98,13 +99,15 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
+ "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.2"
-source = "git+https://github.com/clap-rs/clap/#52814b893c87e1c0350cae13fc1988fe2aa9886a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -579,9 +582,9 @@ checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "os_str_bytes"
-version = "3.0.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e293568965aea261bdf010db17df7030e3c9a275c415d51d6112f7cf9b7af012"
+checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
 name = "parking_lot"
@@ -1158,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.13.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd05616119e612a8041ef58f2b578906cc2531a6069047ae092cfb86a325d835"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,6 +11,6 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 walkdir = "2"
-clap = { git = "https://github.com/clap-rs/clap/" }
+clap = "3.0.0-beta.2"
 yansi = "0.5.0"
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -2,8 +2,28 @@
 //
 // This example demonstrates clap's "usage strings" method of creating arguments
 // which is less verbose
-use clap::App;
+use clap::Clap;
 use std::path::PathBuf;
+
+#[derive(Clap)]
+#[clap(
+    version = "0.0.0",
+    author = "Edward Faulkner <edward@eaf4.com>",
+    about = "The webserver for mho ServiceWorker-based builds."
+)]
+struct Opts {
+    /// Path to your project (defaults to current working directory)
+    #[clap(short, long, value_name = "DIR")]
+    project_root: Option<PathBuf>,
+
+    /// Optionally serve a local directory of prebuilt packages at /deps/
+    #[clap(short, long, value_name = "DIR")]
+    deps: Option<PathBuf>,
+
+    /// Serve a locally-built copy of the worker JavaScript instead of the built-in copy
+    #[clap(short, long, value_name = "DIR")]
+    worker_js: Option<PathBuf>,
+}
 
 pub struct ProjectConfig {
     pub root: PathBuf,
@@ -12,33 +32,26 @@ pub struct ProjectConfig {
 }
 
 pub fn options() -> ProjectConfig {
-    let matches = App::new("mho")
-        .version("0.0.0")
-        .author("Edward Faulkner <edward@eaf4.com>")
-        .about("The webserver for mho ServiceWorker-based builds.")
-        .arg("-r, --project-root=[DIR] 'Path to your project (defaults to current working directory)'")
-        .arg("-d, --deps=[DIR] 'Optionally serve a local directory of prebuilt packages at /deps/'")
-        .arg("-w, --worker-js=[DIR] 'Serve a locally-built copy of the worker JavaScript instead of the built-in copy'")
-        .get_matches();
+    let opts: Opts = Opts::parse();
 
-    let root = match matches.value_of("project-root") {
-        Some(d) => PathBuf::from(d),
+    let root = match opts.project_root {
+        Some(d) => d,
         None => PathBuf::from("."),
     }
     .canonicalize()
     .unwrap();
 
-    let deps = match matches.value_of("deps") {
+    let deps = match opts.deps {
         // using unwrap on purpose here so you get a crash instead of an ignored
         // option
-        Some(d) => Some(PathBuf::from(d).canonicalize().unwrap()),
+        Some(d) => Some(d.canonicalize().unwrap()),
         None => None,
     };
 
-    let worker = match matches.value_of("worker-js") {
+    let worker = match opts.worker_js {
         // using unwrap on purpose here so you get a crash instead of an ignored
         // option
-        Some(d) => Some(PathBuf::from(d).canonicalize().unwrap()),
+        Some(d) => Some(d.canonicalize().unwrap()),
         None => None,
     };
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -14,21 +14,21 @@ use std::path::PathBuf;
 struct Opts {
     /// Path to your project (defaults to current working directory)
     #[clap(
-        short,
-        long,
+        short = 'p',
+        long = "project-root",
         value_name = "DIR",
         default_value = ".",
         hide_default_value = true
     )]
-    project_root: PathBuf,
+    root: PathBuf,
 
     /// Optionally serve a local directory of prebuilt packages at /deps/
     #[clap(short, long, value_name = "DIR")]
     deps: Option<PathBuf>,
 
     /// Serve a locally-built copy of the worker JavaScript instead of the built-in copy
-    #[clap(short, long, value_name = "DIR")]
-    worker_js: Option<PathBuf>,
+    #[clap(short, long = "worker-js", value_name = "DIR")]
+    worker: Option<PathBuf>,
 }
 
 pub struct ProjectConfig {
@@ -40,9 +40,9 @@ pub struct ProjectConfig {
 pub fn options() -> ProjectConfig {
     let opts: Opts = Opts::parse();
 
-    let root = opts.project_root.canonicalize().unwrap();
+    let root = opts.root.canonicalize().unwrap();
     let deps = opts.deps.map(|d| d.canonicalize().unwrap());
-    let worker = opts.worker_js.map(|d| d.canonicalize().unwrap());
+    let worker = opts.worker.map(|d| d.canonicalize().unwrap());
 
     ProjectConfig { deps, worker, root }
 }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -13,8 +13,14 @@ use std::path::PathBuf;
 )]
 struct Opts {
     /// Path to your project (defaults to current working directory)
-    #[clap(short, long, value_name = "DIR")]
-    project_root: Option<PathBuf>,
+    #[clap(
+        short,
+        long,
+        value_name = "DIR",
+        default_value = ".",
+        hide_default_value = true
+    )]
+    project_root: PathBuf,
 
     /// Optionally serve a local directory of prebuilt packages at /deps/
     #[clap(short, long, value_name = "DIR")]
@@ -34,12 +40,7 @@ pub struct ProjectConfig {
 pub fn options() -> ProjectConfig {
     let opts: Opts = Opts::parse();
 
-    let root = opts
-        .project_root
-        .unwrap_or_else(|| PathBuf::from("."))
-        .canonicalize()
-        .unwrap();
-
+    let root = opts.project_root.canonicalize().unwrap();
     let deps = opts.deps.map(|d| d.canonicalize().unwrap());
     let worker = opts.worker_js.map(|d| d.canonicalize().unwrap());
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -18,13 +18,13 @@ pub struct ProjectConfig {
     )]
     pub root: PathBuf,
 
-    /// Optionally serve a local directory of prebuilt packages at /deps/
-    #[clap(short, long, value_name = "DIR")]
-    pub deps: Option<PathBuf>,
-
     /// Serve a locally-built copy of the worker JavaScript instead of the built-in copy
     #[clap(short, long = "worker-js", value_name = "DIR")]
     pub worker: Option<PathBuf>,
+
+    /// Optionally serve a local directory of prebuilt packages at /deps/
+    #[clap(short, long, value_name = "DIR")]
+    pub deps: Option<PathBuf>,
 }
 
 pub fn options() -> ProjectConfig {

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -1,7 +1,3 @@
-// (Full example with detailed comments in examples/01a_quick_example.rs)
-//
-// This example demonstrates clap's "usage strings" method of creating arguments
-// which is less verbose
 use clap::Clap;
 use std::path::PathBuf;
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -32,11 +32,11 @@ pub struct ProjectConfig {
 }
 
 pub fn options() -> ProjectConfig {
-    let opts: ProjectConfig = ProjectConfig::parse();
+    let mut opts: ProjectConfig = ProjectConfig::parse();
 
-    let root = opts.root.canonicalize().unwrap();
-    let deps = opts.deps.map(|d| d.canonicalize().unwrap());
-    let worker = opts.worker.map(|d| d.canonicalize().unwrap());
+    opts.root = opts.root.canonicalize().unwrap();
+    opts.deps = opts.deps.map(|d| d.canonicalize().unwrap());
+    opts.worker = opts.worker.map(|d| d.canonicalize().unwrap());
 
-    ProjectConfig { deps, worker, root }
+    opts
 }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -34,26 +34,14 @@ pub struct ProjectConfig {
 pub fn options() -> ProjectConfig {
     let opts: Opts = Opts::parse();
 
-    let root = match opts.project_root {
-        Some(d) => d,
-        None => PathBuf::from("."),
-    }
-    .canonicalize()
-    .unwrap();
+    let root = opts
+        .project_root
+        .unwrap_or_else(|| PathBuf::from("."))
+        .canonicalize()
+        .unwrap();
 
-    let deps = match opts.deps {
-        // using unwrap on purpose here so you get a crash instead of an ignored
-        // option
-        Some(d) => Some(d.canonicalize().unwrap()),
-        None => None,
-    };
-
-    let worker = match opts.worker_js {
-        // using unwrap on purpose here so you get a crash instead of an ignored
-        // option
-        Some(d) => Some(d.canonicalize().unwrap()),
-        None => None,
-    };
+    let deps = opts.deps.map(|d| d.canonicalize().unwrap());
+    let worker = opts.worker_js.map(|d| d.canonicalize().unwrap());
 
     ProjectConfig { deps, worker, root }
 }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -5,7 +5,7 @@
 use clap::Clap;
 use std::path::PathBuf;
 
-#[derive(Clap)]
+#[derive(Clap, Debug)]
 #[clap(
     version = "0.0.0",
     author = "Edward Faulkner <edward@eaf4.com>",

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
     author = "Edward Faulkner <edward@eaf4.com>",
     about = "The webserver for mho ServiceWorker-based builds."
 )]
-struct Opts {
+pub struct ProjectConfig {
     /// Path to your project (defaults to current working directory)
     #[clap(
         short = 'p',
@@ -20,25 +20,19 @@ struct Opts {
         default_value = ".",
         hide_default_value = true
     )]
-    root: PathBuf,
+    pub root: PathBuf,
 
     /// Optionally serve a local directory of prebuilt packages at /deps/
     #[clap(short, long, value_name = "DIR")]
-    deps: Option<PathBuf>,
+    pub deps: Option<PathBuf>,
 
     /// Serve a locally-built copy of the worker JavaScript instead of the built-in copy
     #[clap(short, long = "worker-js", value_name = "DIR")]
-    worker: Option<PathBuf>,
-}
-
-pub struct ProjectConfig {
-    pub root: PathBuf,
     pub worker: Option<PathBuf>,
-    pub deps: Option<PathBuf>,
 }
 
 pub fn options() -> ProjectConfig {
-    let opts: Opts = Opts::parse();
+    let opts: ProjectConfig = ProjectConfig::parse();
 
     let root = opts.root.canonicalize().unwrap();
     let deps = opts.deps.map(|d| d.canonicalize().unwrap());


### PR DESCRIPTION
With v3 of `clap` it is possible to automatically derive a `clap::App` from a regular struct. This PR ultimately adds `#[derive(Clap)]` to the `ProjectConfig` struct and simplifies the `options()` function a little bit. The generated `--help` text should still be identical.