### PR TITLE
server: Simplify lifetimes on `files` by using an anonymous lifetime

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -118,9 +118,9 @@ async fn worker_js_static() -> JavaScript<&'static str> {
 }
 
 #[get("/<path..>", rank = 9)]
-async fn files<'r>(
+async fn files(
     path: PathBuf,
-    project: State<ProjectConfig, 'r>,
+    project: State<'_, ProjectConfig>,
 ) -> Option<CacheHeaders<NamedFile>> {
     let target;
     let mut long_lived = false;


### PR DESCRIPTION
see https://doc.rust-lang.org/edition-guide/rust-2018/ownership-and-lifetimes/the-anonymous-lifetime.html