### PR TITLE
Recommend `cargo +nightly run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This will build _everything_ including the third-party deps (a step you only nee
 2. Install rust nightly (currently tested under 1.52.0-nightly 2fd73fabe)
 
 - install rustup (the defaults are fine): `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
-- switch to nightly: `rustup toolchain install nightly; rustup toolchain default nightly`
+- install rust nightly: `rustup toolchain install nightly`
 
 3. Clone this repo
 

--- a/ember-app/package.json
+++ b/ember-app/package.json
@@ -19,7 +19,7 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "start": "ember serve",
-    "start:mho": "cd ../server && cargo run -- -r ../ember-app -d ../deps/dist -w ../worker/dist",
+    "start:mho": "cd ../server && cargo +nightly run -- -r ../ember-app -d ../deps/dist -w ../worker/dist",
     "test": "npm-run-all lint test:*",
     "test:ember": "ember test"
   },


### PR DESCRIPTION
... instead of setting the global default toolchain to `nightly`

Unfortunately `rocket` still requires a nightly compiler version, but users with other Rust projects probably shouldn't use nightly by default. Instead of setting the global default toolchain, we can use `cargo +nightly` to choose the nightly toolchain when we work on the mho server.