### PR TITLE
server/cli: Fix `root` short option

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 pub struct ProjectConfig {
     /// Path to your project (defaults to current working directory)
     #[clap(
-        short = 'p',
+        short = 'r',
         long = "project-root",
         value_name = "DIR",
         default_value = ".",


### PR DESCRIPTION
Before #3 the option used to be `-r`, not `-p`. Apparently I got confused by the `--project-root` option name. 🤦 